### PR TITLE
Index filter in the JSON is `f`

### DIFF
--- a/CustomJSONData/CustomBeatmap/SaveData/CustomBeatmapSaveData.cs
+++ b/CustomJSONData/CustomBeatmap/SaveData/CustomBeatmapSaveData.cs
@@ -20,7 +20,7 @@ namespace CustomJSONData.CustomBeatmap
         private const string _tailLayer = "ty";
         private const string _eventBoxes = "e";
         private const string _groupId = "g";
-        private const string _indexFilter = "i";
+        private const string _indexFilter = "f";
         private const string _beatDistributionParam = "w";
         private const string _beatDistributionParamType = "d";
 


### PR DESCRIPTION
No idea how this isn't broken in production. BeatGames uses `f` in `EventBox` beatmap v3 