### PR TITLE
Port to BSIPA 4.3.0

### DIFF
--- a/CustomJSONData/CustomBeatmap/CustomBeatmapData.cs
+++ b/CustomJSONData/CustomBeatmap/CustomBeatmapData.cs
@@ -62,29 +62,14 @@ namespace CustomJSONData.CustomBeatmap
             return type;
         }
 
-        public override void AddBeatmapObjectData(BeatmapObjectData beatmapObjectData)
+        internal void PreAddBeatmapObjectData(BeatmapObjectData beatmapObjectData)
         {
             _beatmapObjectDatas.Add(beatmapObjectData);
-            base.AddBeatmapObjectData(beatmapObjectData);
         }
 
-        // InOrder variants do not use a virtual call to AddBeatmapObjectData so they will not call the above method
-        public override void AddBeatmapObjectDataInOrder(BeatmapObjectData beatmapObjectData)
-        {
-            _beatmapObjectDatas.Add(beatmapObjectData);
-            base.AddBeatmapObjectDataInOrder(beatmapObjectData);
-        }
-
-        public override void InsertBeatmapEventData(BeatmapEventData beatmapEventData)
+        internal void PreInsertBeatmapEventData(BeatmapEventData beatmapEventData)
         {
             _beatmapEventDatas.Add(beatmapEventData);
-            base.InsertBeatmapEventData(beatmapEventData);
-        }
-
-        public override void InsertBeatmapEventDataInOrder(BeatmapEventData beatmapEventData)
-        {
-            _beatmapEventDatas.Add(beatmapEventData);
-            base.InsertBeatmapEventDataInOrder(beatmapEventData);
         }
 
         public void InsertCustomEventData(CustomEventData customEventData)
@@ -102,67 +87,6 @@ namespace CustomJSONData.CustomBeatmap
         {
             InsertCustomEventData(customEventData);
             InsertToAllBeatmapData(customEventData);
-        }
-
-        public override BeatmapData GetCopy()
-        {
-            CustomBeatmapData beatmapData = new(
-                _numberOfLines,
-                version2_6_0AndEarlier,
-                customData.Copy(),
-                beatmapCustomData.Copy(),
-                levelCustomData.Copy());
-            foreach (BeatmapDataItem beatmapDataItem in allBeatmapDataItems)
-            {
-                BeatmapDataItem copy = beatmapDataItem.GetCopy();
-                switch (copy)
-                {
-                    case BeatmapEventData beatmapEventData:
-                        beatmapData.InsertBeatmapEventDataInOrder(beatmapEventData);
-                        break;
-                    case BeatmapObjectData beatmapObjectData:
-                        beatmapData.AddBeatmapObjectDataInOrder(beatmapObjectData);
-                        break;
-                    case CustomEventData customEventData:
-                        beatmapData.InsertCustomEventDataInOrder(customEventData);
-                        break;
-                }
-            }
-
-            return beatmapData;
-        }
-
-        public override BeatmapData GetFilteredCopy(Func<BeatmapDataItem, BeatmapDataItem> processDataItem)
-        {
-            _isCreatingFilteredCopy = true;
-            CustomBeatmapData beatmapData = new(
-                _numberOfLines,
-                version2_6_0AndEarlier,
-                customData.Copy(),
-                beatmapCustomData.Copy(),
-                levelCustomData.Copy());
-            foreach (BeatmapDataItem beatmapDataItem in allBeatmapDataItems)
-            {
-                BeatmapDataItem copy = processDataItem(beatmapDataItem.GetCopy());
-                if (copy != null)
-                {
-                    switch (copy)
-                    {
-                        case BeatmapEventData beatmapEventData:
-                            beatmapData.InsertBeatmapEventDataInOrder(beatmapEventData);
-                            break;
-                        case BeatmapObjectData beatmapObjectData:
-                            beatmapData.AddBeatmapObjectDataInOrder(beatmapObjectData);
-                            break;
-                        case CustomEventData customEventData:
-                            beatmapData.InsertCustomEventDataInOrder(customEventData);
-                            break;
-                    }
-                }
-            }
-
-            _isCreatingFilteredCopy = false;
-            return beatmapData;
         }
     }
 }

--- a/CustomJSONData/CustomBeatmap/CustomBeatmapDataSortedListForTypes.cs
+++ b/CustomJSONData/CustomBeatmap/CustomBeatmapDataSortedListForTypes.cs
@@ -16,22 +16,5 @@ namespace CustomJSONData.CustomBeatmap
             _itemsAccessor(ref @this) = _itemsAccessor(ref original);
             _sortedListsDataProcessors.Add(typeof(CustomEventData), null);
         }
-
-        // GetType is a real stinky way of indexing stuff
-        public override LinkedListNode<TBase> InsertItem(TBase item)
-        {
-            LinkedListNode<TBase> linkedListNode = GetList(CustomBeatmapData.GetCustomType(item), item.subtypeGroupIdentifier).Insert(item);
-            _itemToNodeMap[item] = linkedListNode;
-            return linkedListNode;
-        }
-
-        public override void RemoveItem(TBase item)
-        {
-            ISortedList<TBase> list = GetList(CustomBeatmapData.GetCustomType(item), item.subtypeGroupIdentifier);
-            if (_itemToNodeMap.TryGetValue(item, out LinkedListNode<TBase> node))
-            {
-                list.Remove(node);
-            }
-        }
     }
 }

--- a/CustomJSONData/CustomBeatmap/CustomConverters.cs
+++ b/CustomJSONData/CustomBeatmap/CustomConverters.cs
@@ -30,17 +30,6 @@ namespace CustomJSONData.CustomBeatmap
                 ? customData.customData : new CustomData();
         }
 
-        [UsedImplicitly]
-        public class CustomDataConverter<T> : DataConvertor<T>
-        {
-            public override T ProcessItem(object item)
-            {
-                return _convertors.TryGetValue(CustomBeatmapData.GetCustomType(item), out DataItemConvertor<T> dataItemConvertor)
-                    ? dataItemConvertor.Convert(item)
-                    : default!;
-            }
-        }
-
         public class CustomColorNoteConverter
             : BeatmapDataLoader.BeatmapDataItemConvertor<BeatmapObjectData, BeatmapSaveData.ColorNoteData, NoteData>
         {
@@ -50,7 +39,7 @@ namespace CustomJSONData.CustomBeatmap
             {
             }
 
-            protected override NoteData Convert(BeatmapSaveData.ColorNoteData data)
+            public override NoteData Convert(BeatmapSaveData.ColorNoteData data)
             {
                 NoteData noteData = CustomNoteData.CreateCustomBasicNoteData(
                     BeatToTime(data.beat),
@@ -73,7 +62,7 @@ namespace CustomJSONData.CustomBeatmap
             {
             }
 
-            protected override NoteData Convert(BeatmapSaveData.BombNoteData data)
+            public override NoteData Convert(BeatmapSaveData.BombNoteData data)
             {
                 return CustomNoteData.CreateCustomBombNoteData(
                     BeatToTime(data.beat),
@@ -100,7 +89,7 @@ namespace CustomJSONData.CustomBeatmap
             {
             }
 
-            protected override ObstacleData Convert(BeatmapSaveData.ObstacleData data)
+            public override ObstacleData Convert(BeatmapSaveData.ObstacleData data)
             {
                 float beat = BeatToTime(data.beat);
                 return new CustomObstacleData(
@@ -123,7 +112,7 @@ namespace CustomJSONData.CustomBeatmap
             {
             }
 
-            protected override SliderData Convert(BeatmapSaveData.SliderData data)
+            public override SliderData Convert(BeatmapSaveData.SliderData data)
             {
                 return CustomSliderData.CreateCustomSliderData(
                     _convertColorType(data.colorType),
@@ -153,7 +142,7 @@ namespace CustomJSONData.CustomBeatmap
             {
             }
 
-            protected override SliderData Convert(BeatmapSaveData.BurstSliderData data)
+            public override SliderData Convert(BeatmapSaveData.BurstSliderData data)
             {
                 return CustomSliderData.CreateCustomBurstSliderData(
                     _convertColorType(data.colorType),
@@ -182,7 +171,7 @@ namespace CustomJSONData.CustomBeatmap
             {
             }
 
-            protected override WaypointData Convert(BeatmapSaveData.WaypointData data)
+            public override WaypointData Convert(BeatmapSaveData.WaypointData data)
             {
                 return new CustomWaypointData(
                     BeatToTime(data.beat),
@@ -202,7 +191,7 @@ namespace CustomJSONData.CustomBeatmap
             {
             }
 
-            protected override BPMChangeBeatmapEventData Convert(BeatmapSaveData.BpmChangeEventData data)
+            public override BPMChangeBeatmapEventData Convert(BeatmapSaveData.BpmChangeEventData data)
             {
                 return new CustomBPMChangeBeatmapEventData(
                     BeatToTime(data.beat),
@@ -220,7 +209,7 @@ namespace CustomJSONData.CustomBeatmap
             {
             }
 
-            protected override SpawnRotationBeatmapEventData Convert(BeatmapSaveData.RotationEventData data)
+            public override SpawnRotationBeatmapEventData Convert(BeatmapSaveData.RotationEventData data)
             {
                 SpawnRotationBeatmapEventData.SpawnRotationEventType executionTime =
                     data.executionTime == BeatmapSaveData.ExecutionTime.Early
@@ -248,7 +237,7 @@ namespace CustomJSONData.CustomBeatmap
                 _specialEventsFilter = specialEventsFilter;
             }
 
-            protected override BasicBeatmapEventData Convert(BeatmapSaveData.BasicEventData data)
+            public override BasicBeatmapEventData Convert(BeatmapSaveData.BasicEventData data)
             {
                 if (!_specialEventsFilter.IsEventValid(data.eventType))
                 {
@@ -273,7 +262,7 @@ namespace CustomJSONData.CustomBeatmap
             {
             }
 
-            protected override ColorBoostBeatmapEventData Convert(BeatmapSaveData.ColorBoostEventData data)
+            public override ColorBoostBeatmapEventData Convert(BeatmapSaveData.ColorBoostEventData data)
             {
                 return new CustomColorBoostBeatmapEventData(
                     BeatToTime(data.beat),

--- a/CustomJSONData/CustomJSONData.csproj
+++ b/CustomJSONData/CustomJSONData.csproj
@@ -14,7 +14,7 @@
     <Reference Include="BeatmapCore" HintPath="$(BeatSaberDir)\Beat Saber_Data\Managed\BeatmapCore.dll" />
     <Reference Include="HMLib" HintPath="$(BeatSaberDir)\Beat Saber_Data\Managed\HMLib.dll" />
     <Reference Include="IPA.Loader" HintPath="$(BeatSaberDir)\Beat Saber_Data\Managed\IPA.Loader.dll" />
-    <Reference Include="Main" HintPath="$(BeatSaberDir)\Beat Saber_Data\Managed\Main.dll" />
+    <Reference Include="Main" Publicize="true" HintPath="$(BeatSaberDir)\Beat Saber_Data\Managed\Main.dll" />
     <Reference Include="Newtonsoft.Json" HintPath="$(BeatSaberDir)\Libs\Newtonsoft.Json.dll" />
     <Reference Include="Tweening" HintPath="$(BeatSaberDir)\Beat Saber_Data\Managed\Tweening.dll" />
     <Reference Include="UnityEngine.CoreModule" HintPath="$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.CoreModule.dll" />
@@ -27,6 +27,10 @@
 
   <ItemGroup>
     <PackageReference Include="BeatSaberModdingTools.Tasks" Version="1.4.3" />
+    <PackageReference Include="BepInEx.AssemblyPublicizer.MSBuild" Version="0.4.1">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.354" />
   </ItemGroup>
 </Project>

--- a/CustomJSONData/HarmonyPatches/CustomBeatmapData/BeatmapDataCustomify.cs
+++ b/CustomJSONData/HarmonyPatches/CustomBeatmapData/BeatmapDataCustomify.cs
@@ -1,0 +1,107 @@
+﻿using System;
+using CustomJSONData.CustomBeatmap;
+using HarmonyLib;
+
+namespace CustomJSONData.HarmonyPatches
+{
+    [HarmonyPatch(typeof(BeatmapData))]
+    internal static class BeatmapDataCustomify
+    {
+        [HarmonyPrefix]
+        [HarmonyPatch(nameof(BeatmapData.AddBeatmapObjectData))]
+        private static void PreAddBeatmapObjectData(BeatmapObjectData beatmapObjectData, BeatmapData __instance)
+        {
+            ((CustomBeatmapData)__instance).PreAddBeatmapObjectData(beatmapObjectData);
+        }
+
+        [HarmonyPrefix]
+        [HarmonyPatch(nameof(BeatmapData.AddBeatmapObjectDataInOrder))]
+        private static void PreAddBeatmapObjectDataInOrder(BeatmapObjectData beatmapObjectData, BeatmapData __instance)
+        {
+            ((CustomBeatmapData)__instance).PreAddBeatmapObjectData(beatmapObjectData);
+        }
+
+        [HarmonyPrefix]
+        [HarmonyPatch(nameof(BeatmapData.InsertBeatmapEventData))]
+        private static void PreInsertBeatmapEventData(BeatmapEventData beatmapEventData, BeatmapData __instance)
+        {
+            ((CustomBeatmapData)__instance).PreInsertBeatmapEventData(beatmapEventData);
+        }
+
+        [HarmonyPrefix]
+        [HarmonyPatch(nameof(BeatmapData.InsertBeatmapEventDataInOrder))]
+        private static void PreInsertBeatmapEventDataInOrder(BeatmapEventData beatmapEventData, BeatmapData __instance)
+        {
+            ((CustomBeatmapData)__instance).PreInsertBeatmapEventData(beatmapEventData);
+        }
+
+        [HarmonyPrefix]
+        [HarmonyPatch(nameof(BeatmapData.GetCopy))]
+        public static bool GetCopy(BeatmapData __instance, ref BeatmapData __result)
+        {
+            CustomBeatmapData original = (CustomBeatmapData)__instance;
+            CustomBeatmapData beatmapData = new(
+                original._numberOfLines,
+                original.version2_6_0AndEarlier,
+                original.customData.Copy(),
+                original.beatmapCustomData.Copy(),
+                original.levelCustomData.Copy());
+            foreach (BeatmapDataItem beatmapDataItem in original.allBeatmapDataItems)
+            {
+                BeatmapDataItem copy = beatmapDataItem.GetCopy();
+                switch (copy)
+                {
+                    case BeatmapEventData beatmapEventData:
+                        beatmapData.InsertBeatmapEventDataInOrder(beatmapEventData);
+                        break;
+                    case BeatmapObjectData beatmapObjectData:
+                        beatmapData.AddBeatmapObjectDataInOrder(beatmapObjectData);
+                        break;
+                    case CustomEventData customEventData:
+                        beatmapData.InsertCustomEventDataInOrder(customEventData);
+                        break;
+                }
+            }
+
+            __result = beatmapData;
+            return false;
+        }
+
+        [HarmonyPrefix]
+        [HarmonyPatch(nameof(BeatmapData.GetFilteredCopy))]
+        public static bool GetFilteredCopy(Func<BeatmapDataItem, BeatmapDataItem> processDataItem, BeatmapData __instance, ref BeatmapData __result)
+        {
+            CustomBeatmapData original = (CustomBeatmapData)__instance;
+            original._isCreatingFilteredCopy = true;
+            CustomBeatmapData beatmapData = new(
+                original._numberOfLines,
+                original.version2_6_0AndEarlier,
+                original.customData.Copy(),
+                original.beatmapCustomData.Copy(),
+                original.levelCustomData.Copy());
+            foreach (BeatmapDataItem beatmapDataItem in original.allBeatmapDataItems)
+            {
+                BeatmapDataItem copy = processDataItem(beatmapDataItem.GetCopy());
+                if (copy != null)
+                {
+                    switch (copy)
+                    {
+                        case BeatmapEventData beatmapEventData:
+                            beatmapData.InsertBeatmapEventDataInOrder(beatmapEventData);
+                            break;
+                        case BeatmapObjectData beatmapObjectData:
+                            beatmapData.AddBeatmapObjectDataInOrder(beatmapObjectData);
+                            break;
+                        case CustomEventData customEventData:
+                            beatmapData.InsertCustomEventDataInOrder(customEventData);
+                            break;
+                    }
+                }
+            }
+
+            original._isCreatingFilteredCopy = false;
+            __result = beatmapData;
+            return false;
+        }
+    }
+}

--- a/CustomJSONData/HarmonyPatches/CustomBeatmapData/BeatmapDataLoaderCustomify.cs
+++ b/CustomJSONData/HarmonyPatches/CustomBeatmapData/BeatmapDataLoaderCustomify.cs
@@ -78,16 +78,12 @@ namespace CustomJSONData.HarmonyPatches
                     new CodeInstruction(OpCodes.Call, _addCustomEvent))
 
                 // "convertor" is NOT the correct spelling
-                .ReplaceConverter<DataConvertor<BeatmapObjectData>, Converters.CustomDataConverter<BeatmapObjectData>>()
-
                 .ReplaceConverter<BeatmapDataLoader.ColorNoteConvertor, Converters.CustomColorNoteConverter>()
                 .ReplaceConverter<BeatmapDataLoader.BombNoteConvertor, Converters.CustomBombNoteConverter>()
                 .ReplaceConverter<BeatmapDataLoader.ObstacleConvertor, Converters.CustomObstacleConverter>()
                 .ReplaceConverter<BeatmapDataLoader.SliderConvertor, Converters.CustomSliderConverter>()
                 .ReplaceConverter<BeatmapDataLoader.BurstSliderConvertor, Converters.CustomBurstSliderConverter>()
                 .ReplaceConverter<BeatmapDataLoader.WaypointConvertor, Converters.CustomWaypointConverter>()
-
-                .ReplaceConverter<DataConvertor<BeatmapEventData>, Converters.CustomDataConverter<BeatmapEventData>>()
 
                 .ReplaceConverter<BeatmapDataLoader.BpmEventConvertor, Converters.CustomBpmEventConverter>()
                 .ReplaceConverter<BeatmapDataLoader.RotationEventConvertor, Converters.CustomRotationEventConverter>()

--- a/CustomJSONData/HarmonyPatches/CustomBeatmapData/BeatmapDataSortedCustomify.cs
+++ b/CustomJSONData/HarmonyPatches/CustomBeatmapData/BeatmapDataSortedCustomify.cs
@@ -1,0 +1,41 @@
+﻿using System.Collections.Generic;
+using System.Reflection;
+using System.Reflection.Emit;
+using CustomJSONData.CustomBeatmap;
+using HarmonyLib;
+using static HarmonyLib.AccessTools;
+
+namespace CustomJSONData.HarmonyPatches
+{
+    [HarmonyPatch(typeof(BeatmapDataSortedListForTypeAndIds<BeatmapDataItem>))]
+    internal static class BeatmapDataSortedCustomify
+    {
+        private static readonly MethodInfo _getType = Method(typeof(object), nameof(GetType));
+        private static readonly MethodInfo _getCustomType = Method(typeof(CustomBeatmapData), nameof(CustomBeatmapData.GetCustomType));
+
+        [HarmonyTranspiler]
+        [HarmonyPatch(nameof(BeatmapDataSortedListForTypeAndIds<BeatmapDataItem>.InsertItem))]
+        private static IEnumerable<CodeInstruction> CustomifyInsertItem(IEnumerable<CodeInstruction> instructions)
+        {
+            return new CodeMatcher(instructions)
+                .CustomifyGetType()
+                .InstructionEnumeration();
+        }
+
+        [HarmonyTranspiler]
+        [HarmonyPatch(nameof(BeatmapDataSortedListForTypeAndIds<BeatmapDataItem>.RemoveItem))]
+        private static IEnumerable<CodeInstruction> CustomifyRemoveItem(IEnumerable<CodeInstruction> instructions)
+        {
+            return new CodeMatcher(instructions)
+                .CustomifyGetType()
+                .InstructionEnumeration();
+        }
+
+        private static CodeMatcher CustomifyGetType(this CodeMatcher matcher)
+        {
+            return matcher
+                .MatchForward(false, new CodeMatch(OpCodes.Callvirt, _getType))
+                .Set(OpCodes.Call, _getCustomType);
+        }
+    }
+}

--- a/CustomJSONData/HarmonyPatches/CustomConverters/DataConverterCustomify.cs
+++ b/CustomJSONData/HarmonyPatches/CustomConverters/DataConverterCustomify.cs
@@ -1,0 +1,26 @@
+﻿using System.Collections.Generic;
+using System.Reflection;
+using System.Reflection.Emit;
+using CustomJSONData.CustomBeatmap;
+using HarmonyLib;
+using static HarmonyLib.AccessTools;
+
+namespace CustomJSONData.HarmonyPatches.CustomConverters
+{
+    [HarmonyPatch(typeof(DataConvertor<BeatmapDataItem>))]
+    internal static class DataConverterCustomify
+    {
+        private static readonly MethodInfo _getType = Method(typeof(object), nameof(GetType));
+        private static readonly MethodInfo _getCustomType = Method(typeof(CustomBeatmapData), nameof(CustomBeatmapData.GetCustomType));
+
+        [HarmonyTranspiler]
+        [HarmonyPatch(nameof(DataConvertor<BeatmapDataItem>.ProcessItem))]
+        private static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
+        {
+            return new CodeMatcher(instructions)
+                .MatchForward(false, new CodeMatch(OpCodes.Callvirt, _getType))
+                .Set(OpCodes.Call, _getCustomType)
+                .InstructionEnumeration();
+        }
+    }
+}

--- a/CustomJSONData/manifest.json
+++ b/CustomJSONData/manifest.json
@@ -4,7 +4,7 @@
   "description": "Lets mappers include arbitrary data in beatmaps, and lets modders access that data. Why did I make this? Good question.",
   "gameVersion": "1.26.1",
   "dependsOn": {
-    "BSIPA": "^4.2.2"
+    "BSIPA": "^4.3.0"
   },
   "id": "CustomJSONData",
   "name": "CustomJSONData",


### PR DESCRIPTION
This patch is mostly working around removal of assembly virtualization, which this mod heavily relies upon. I replaced almost all usages of virtualized methods with Harmony patches. There are also differences between BSIPA's publicization and [`BepInEx.AssemblyPublicizer`](https://github.com/BepInEx/BepInEx.AssemblyPublicizer) that I need to work with, which fortunately is much easier.

Miraculously works without immediate problems under 1.30.2.

The patch's slightly hacky; There might be better solutions.