### PR TITLE
Allow Negative Size/Duration walls for Beatmap V3

### DIFF
--- a/CustomJSONData/HarmonyPatches/CustomBeatmapData/ConvertersCustomify.cs
+++ b/CustomJSONData/HarmonyPatches/CustomBeatmapData/ConvertersCustomify.cs
@@ -105,13 +105,43 @@ namespace CustomJSONData.HarmonyPatches
             return instructions.ReplaceMethod(_version3, _createBombNoteData, _createCustomBombNoteData);
         }
 
-        [HarmonyTranspiler]
+        /*[HarmonyTranspiler]
         [HarmonyPatch(
             typeof(BeatmapDataLoaderVersion3.BeatmapDataLoader.ObstacleConverter),
             nameof(BeatmapDataLoaderVersion3.BeatmapDataLoader.ObstacleConverter.Convert))]
         private static IEnumerable<CodeInstruction> ObstacleConvertV3(IEnumerable<CodeInstruction> instructions)
         {
             return instructions.ReplaceCtor(_version3, _obstacleDataCtor, _customObstacleDataCtor);
+        }*/
+
+        [HarmonyPrefix]
+        [HarmonyPatch(
+            typeof(BeatmapDataLoaderVersion3.BeatmapDataLoader.ObstacleConverter),
+            nameof(BeatmapDataLoaderVersion3.BeatmapDataLoader.ObstacleConverter.Convert))]
+        private static bool ObstacleConvertV3(
+            BeatmapDataLoaderVersion3.BeatmapDataLoader.ObstacleConverter __instance,
+            BeatmapSaveDataVersion3.ObstacleData obstacleSaveData,
+            ref BeatmapObjectData? __result)
+        {
+            float time = __instance.BeatToTime(obstacleSaveData.beat);
+            float endBeat = obstacleSaveData.beat + obstacleSaveData.duration;
+            float duration = __instance.BeatToTime(endBeat) - time;
+
+            __result = new CustomObstacleData(
+                time,
+#if !PRE_V1_39_1
+                obstacleSaveData.beat,
+                endBeat,
+                __instance.BeatToRotation(obstacleSaveData.beat),
+#endif
+                obstacleSaveData.line,
+                BeatmapDataLoaderVersion3.BeatmapDataLoader.ObstacleConverter.GetNoteLineLayer(obstacleSaveData.layer),
+                duration,
+                obstacleSaveData.width,
+                obstacleSaveData.height,
+                obstacleSaveData.GetData(),
+                BeatmapSaveDataHelpers.version3);
+            return false;
         }
 
         [HarmonyTranspiler]


### PR DESCRIPTION
CustomJSONData currently has this fixed, but only for V2 Beatmaps. V3 Beatmaps are, however, still affected in v1.39.1

This patch should allow V3 beatmaps that has negative size/duration walls to properly load. I ensured I incorporated this patch similarly to how you did for V2 beatmaps, to ensure it doesn't break mapping extensions.

Feel free to double check my work to make sure I applied this properly, but it seems to work fine for "Superluminal" which utilized negative duration, as a v3 beatmap.

Edit: Fixed formatting and positioning of the patch, as well as commented out the original ObstacleConverter patch.